### PR TITLE
Fix bug with reserved keyword names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## 3.0.0 - 2025-08-27
+## 3.0.1 - 2025-08-20
+### Fixed
+- Fixed a bug in the `droid-metapatch` that did not correctly name reserved parameters such as `else` to `else_`.
+
+## 3.0.0 - 2025-08-17
 ### Changed
 
 - Completely rewritten the logic for the circuits.

--- a/metapatch/factory/patch_factory.py
+++ b/metapatch/factory/patch_factory.py
@@ -111,7 +111,7 @@ def _generate_circuit_params(circuitname: str, circuit: TCircuitParams, level: i
             continue
         realkey = circuit_params[key]
         if realkey in keyword.kwlist:
-            key += "_"
+            realkey += "_"
         statement = context.eval_template(
             "fun_quoted_assignment", key=realkey, val=value, comma=True
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "droid-metapatch"
-version = "3.0.0"
+version = "3.0.1"
 description = "DROID patch generator"
 authors = [{ name = "Allan Eising", email = "allan@eising.dk" }]
 requires-python = ">=3.12"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,7 @@
 """Test factory functions."""
 
 from metapatch.factory.patch_parser import tokenize
+from metapatch.factory.boilerplate import generate_snippet
 
 def test_minified_tokenizer() -> None:
     """Test the tokenizer's ability to test a minified patch."""
@@ -40,3 +41,15 @@ sc=_T1_FADERMODE_UPDATED"""
         expected += f"{param}={value}\n"
 
     assert expected == testpatch
+
+def test_reserved_keywords() -> None:
+    """Test reserved keywords."""
+    rawpatch = """
+[compare]
+input="_INPUT"
+compare="1"
+ifequal="1"
+else="0"
+    """
+    snippet = generate_snippet(rawpatch)
+    assert "else_" in snippet

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "droid-metapatch"
-version = "3.0.0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Keywords such as `else` were not correctly translated to their non-reserved name, e.g.,`else_` 